### PR TITLE
feat: support delegating password encoder

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/PasswordEncoderConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/PasswordEncoderConfig.java
@@ -4,8 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
 
 @Configuration
 public class PasswordEncoderConfig {
@@ -13,9 +17,17 @@ public class PasswordEncoderConfig {
     private static Logger logger = LoggerFactory.getLogger(PasswordEncoderConfig.class);
 
     @Bean
-    public PasswordEncoder nonCachingPasswordEncoder() {
-        logger.info("Building BackwardsCompatibleDelegatingPasswordEncoder with {bcrypt} only");
+    public PasswordEncoder nonCachingPasswordEncoder(Environment environment) {
+        String encodingId = configuredDatabaseEncodingId(environment);
+        logger.info(String.format("Building DelegatingPasswordEncoder with desired encoder {%s}", encodingId));
 
-        return new BackwardsCompatibleDelegatingPasswordEncoder(new BCryptPasswordEncoder());
+        DelegatingPasswordEncoder passwordEncoder = (DelegatingPasswordEncoder)PasswordEncoderFactories.createDelegatingPasswordEncoder(encodingId);
+        passwordEncoder.setDefaultPasswordEncoderForMatches(new BCryptPasswordEncoder());
+
+        return passwordEncoder;
+    }
+
+    private String configuredDatabaseEncodingId(Environment environment) {
+        return Optional.ofNullable(environment.getProperty("database.passwordEncodingId")).orElse("bcrypt");
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/PasswordEncoderFactories.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/PasswordEncoderFactories.java
@@ -1,0 +1,61 @@
+package org.cloudfoundry.identity.uaa.util.beans;
+
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * copied from org.springframework.security.crypto.factory.PasswordEncoderFactories
+ */
+public final class PasswordEncoderFactories {
+
+    /**
+     * Creates a {@link DelegatingPasswordEncoder} with default mappings. Additional
+     * mappings may be added and the encoding will be updated to conform with best
+     * practices. However, due to the nature of {@link DelegatingPasswordEncoder} the
+     * updates should not impact users. The mappings current are:
+     *
+     * <ul>
+     * <li>bcrypt - {@link BCryptPasswordEncoder} (Also used for encoding)</li>
+     * <li>ldap -
+     * {@link org.springframework.security.crypto.password.LdapShaPasswordEncoder}</li>
+     * <li>MD4 -
+     * {@link org.springframework.security.crypto.password.Md4PasswordEncoder}</li>
+     * <li>MD5 - {@code new MessageDigestPasswordEncoder("MD5")}</li>
+     * <li>noop -
+     * {@link org.springframework.security.crypto.password.NoOpPasswordEncoder}</li>
+     * <li>pbkdf2 - {@link Pbkdf2PasswordEncoder}</li>
+     * <li>scrypt - {@link SCryptPasswordEncoder}</li>
+     * <li>SHA-1 - {@code new MessageDigestPasswordEncoder("SHA-1")}</li>
+     * <li>SHA-256 - {@code new MessageDigestPasswordEncoder("SHA-256")}</li>
+     * <li>sha256 -
+     * {@link org.springframework.security.crypto.password.StandardPasswordEncoder}</li>
+     * <li>argon2 - {@link Argon2PasswordEncoder}</li>
+     * </ul>
+     * @return the {@link PasswordEncoder} to use
+     */
+    @SuppressWarnings("deprecation")
+    public static PasswordEncoder createDelegatingPasswordEncoder(final String encodingId) {
+        Map<String, PasswordEncoder> encoders = new HashMap<>();
+        encoders.put("bcrypt", new BCryptPasswordEncoder());
+        encoders.put("ldap", new org.springframework.security.crypto.password.LdapShaPasswordEncoder());
+        encoders.put("MD4", new org.springframework.security.crypto.password.Md4PasswordEncoder());
+        encoders.put("MD5", new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("MD5"));
+        encoders.put("noop", org.springframework.security.crypto.password.NoOpPasswordEncoder.getInstance());
+        encoders.put("pbkdf2", new Pbkdf2PasswordEncoder());
+        encoders.put("scrypt", new SCryptPasswordEncoder());
+        encoders.put("SHA-1", new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("SHA-1"));
+        encoders.put("SHA-256",
+                new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("SHA-256"));
+        encoders.put("sha256", new org.springframework.security.crypto.password.StandardPasswordEncoder());
+        encoders.put("argon2", new Argon2PasswordEncoder());
+        return new DelegatingPasswordEncoder(encodingId, encoders);
+    }
+
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/PasswordEncoderConfig.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/PasswordEncoderConfig.java
@@ -7,9 +7,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class PasswordEncoderConfig {
 
     private static Logger logger = LoggerFactory.getLogger(PasswordEncoderConfig.class);
@@ -17,23 +14,13 @@ public class PasswordEncoderConfig {
     @Bean
     public PasswordEncoder nonCachingPasswordEncoder() {
 
-        PasswordEncoder noopPasswordEncoder = new PasswordEncoder() {
-            @Override
-            public String encode(CharSequence rawPassword) {
-                return rawPassword.toString();
-            }
+        String encodingId = "noop";
 
-            @Override
-            public boolean matches(CharSequence rawPassword, String encodedPassword) {
-                return rawPassword.toString().equals(encodedPassword);
-            }
-        };
+        logger.info(String.format("TEST CONTEXT - Building DelegatingPasswordEncoder with desired encoder {%s}", encodingId));
 
-        logger.info("TEST CONTEXT - Building DelegatingPasswordEncoder with {bcrypt} and {noop} only");
+        DelegatingPasswordEncoder passwordEncoder = (DelegatingPasswordEncoder)PasswordEncoderFactories.createDelegatingPasswordEncoder(encodingId);
+        passwordEncoder.setDefaultPasswordEncoderForMatches(new BCryptPasswordEncoder());
 
-        Map<String, PasswordEncoder> encoders = new HashMap<>();
-        encoders.put("bcrypt", new BCryptPasswordEncoder());
-        encoders.put("noop", noopPasswordEncoder);
-        return new DelegatingPasswordEncoder("noop", encoders);
+        return passwordEncoder;
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/PasswordEncoderFactoriesTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/PasswordEncoderFactoriesTest.java
@@ -1,0 +1,14 @@
+package org.cloudfoundry.identity.uaa.util.beans;
+
+import org.junit.Test;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PasswordEncoderFactoriesTest {
+    @Test
+    public void createDelegatingPasswordEncoder() {
+        String encodingId = "sha256";
+        assertTrue(PasswordEncoderFactories.createDelegatingPasswordEncoder(encodingId) instanceof DelegatingPasswordEncoder);
+    }
+}

--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -21,6 +21,7 @@
 #  abandonedtimeout: 300
 #  evictionintervalms: 15000
 #  caseinsensitive: false
+#  passwordEncodingId: bcrypt
 
 #note - this is not the place to set these properties
 # - they are just here for documentation purposes
@@ -38,6 +39,7 @@
 #  url: jdbc:mysql://localhost:3306/uaa
 #  username: root
 #  password: blabla
+#  passwordEncodingId: bcrypt
 
 #mysql commands that were run
 #create database uaa;

--- a/uaa/src/main/webapp/WEB-INF/spring/oauth-clients.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/oauth-clients.xml
@@ -166,7 +166,7 @@
                             <entry key="secret" value="password"/>
                             <entry key="authorized-grant-types" value="client_credentials"/>
                             <entry key="authorities" value="uaa.none"/>
-                            <entry key="use-bcrypt-prefix" value="true"/>
+                            <entry key="use-bcrypt-prefix" value="false"/>
                         </map>
                     </entry>
                     <entry key="jku_test">


### PR DESCRIPTION
- feat: support DelegatingPasswordEncoder
- chore: set client_with_bcrypt_prefix.use-bcrypt-prefix as false 
  - due to DelegatingPasswordEncoder uses prefix as default
  - don't need to append additional bcrypt-prefix